### PR TITLE
👷 feat: restrict pr to main except development

### DIFF
--- a/.github/workflows/pr-rule.yml
+++ b/.github/workflows/pr-rule.yml
@@ -1,0 +1,17 @@
+name: Restrict PR Source Branch
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  restrict-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR source branch
+        run: |
+          if [[ "${{ github.head_ref }}" != "development" ]]; then
+            echo "❌ Pull requests to main are only allowed from development."
+            exit 1
+          fi


### PR DESCRIPTION
- added restrict pr source branch workflow to restrict any pr to main except development