### PR TITLE
fix: project name & description generation

### DIFF
--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { Listr, ListrTaskWrapper } from 'listr2';
-import { dirname, join } from 'path';
+import { dirname, join, sep } from 'path';
 import { logger } from '../utils/logger';
 import { File } from './file';
 import { Task } from './task';
@@ -65,9 +65,10 @@ export abstract class Project {
 
         const cwd = process.cwd();
 
-        this.name = !name.length ? cwd[cwd.length - 1] : name;
-        this.description =
-            description ?? `Node.js application for ${this.name}`;
+        this.name = !name.length ? cwd.split(sep).slice(-1)[0] : name;
+        this.description = description?.length
+            ? description
+            : `Node.js application for ${this.name}`;
         this.version = version;
         this.author = author ?? '';
         this.packageManager = packageManager;


### PR DESCRIPTION
### Fixes:
- Fixed incorrect name generation when project name is not provided
- Fixed description generation logic
- Related to #14 

### Testing:
- Project name & description getting added
<img width="512" height="420" alt="image" src="https://github.com/user-attachments/assets/2b6aa3df-061a-4400-b109-258f25cb764e" />
