### PR TITLE
fix: fixed failing workflwos auto-pr and release-changelog

### DIFF
--- a/.github/workflows/auto-pr-gen.yml
+++ b/.github/workflows/auto-pr-gen.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - development
-      - stage
-      - main
 
 jobs:
   call-auto-pr:

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Generate ChangeLog
         id: release-changelog
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_REPO_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
# Summary

fixed failing workflwos auto-pr and release-changelog

---

## Type of Change

Select all that apply:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactor
- [ ] ✅ Test addition/fix
- [ ] 🔧 Chore (CI, tooling, dependency updates)
- [ ] Other: <!-- Describe -->

---

## Changes Overview

- Fixed `auto-pr-gen` workflow to trigger on `development` branch
- Fixed `release-changelog` workflow to use latest `googleapis/release-please-action@v4` action
- Updated the secret variable to use PAT in `release-changelog`